### PR TITLE
Style fixes and working syntax highlighting!

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -17,7 +17,10 @@ module.exports = {
       use: "@gridsome/source-filesystem",
       options: {
         typeName: "Doc",
-        path: "docs/**/*.md"
+        path: "docs/**/*.md",
+        remark: {
+          autolinkClassName: " "
+        }
       }
     },
     {

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -28,4 +28,21 @@ $footer-padding: 2rem 3rem 2rem;
 
 // Import Bulma and Buefy styles
 @import "~bulma";
+// An extremely hacky fix to stop bulma's number class from interfering with
+// our markdown syntax highlighting. We can't even not import it since there are
+// other things we want in the bulma/sass/elements/other.sass file :(
+.number {
+  align-items: initial;
+  background-color: initial;
+  border-radius: initial;
+  display: initial;
+  font-size: initial;
+  height: initial;
+  justify-content: initial;
+  margin-right: initial;
+  min-width: initial;
+  padding: initial;
+  text-align: initial;
+  vertical-align: initial;
+}
 @import "~buefy/src/scss/buefy";

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import "bulma-divider/dist/css/bulma-divider.min.css";
 import "@mdi/font/css/materialdesignicons.min.css";
 import axios from "axios";
 import initKeycloak from "~/auth.js";
+import "prismjs/themes/prism.css";
 
 export default async function(Vue, { isClient }) {
   // Set default layout as a global component


### PR DESCRIPTION
This should fix #170 and #169, and introduce nice new syntax highlighting, I just forgot to import the styling for that.

#170 was an easy fix, we just had to override the classes that were causing issues
#169 was more hacky, but I really had no other way around it. I think to really handle this correctly, we should import bulma styles per component, but that might be more overhead for future work.