### PR TITLE
Fix stats dashboard iframe height

### DIFF
--- a/src/pages/Stats.vue
+++ b/src/pages/Stats.vue
@@ -1,11 +1,12 @@
 <template>
   <Layout>
-    <section class="section has-text-centered">
+    <section class="section has-text-centered stats-container">
       <iframe
         src="https://metabase.ocf.berkeley.edu/public/dashboard/ece8bcde-16d0-42dd-bd66-e8e30f256837"
         frameborder="0"
         width="100%"
         height="100%"
+        scrolling="no"
         allowtransparency
       />
     </section>
@@ -19,3 +20,14 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+  .stats-container {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0;
+    width: 100%;
+    height: 350vh;
+  }
+</style>


### PR DESCRIPTION
This is what it looked like before:
![image](https://user-images.githubusercontent.com/15005763/100277074-6595c700-2f17-11eb-9d83-68c4444ddc02.png)

Now:
![image](https://user-images.githubusercontent.com/15005763/100277114-73e3e300-2f17-11eb-9740-256f3219d335.png)

Dynamic iframe resizing requires some DOM manipulation and I'm not sure how nicely that plays with Vue, so I decided to just hard code in a `350vh` tall container. I've verified that all the content shows up on a variety of screen sizes (from phone to 1440p), if anyone has a 4k screen feel free to try that too I guess. Should be good enough for now.