### PR TITLE
Officers

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -26,6 +26,9 @@ $link-focus-border: $primary;
 
 $footer-padding: 2rem 3rem 2rem;
 
+$card-background-color: $primary;
+$card-color: $primary-invert;
+
 // Import Bulma and Buefy styles
 @import "~bulma";
 @import "~buefy/src/scss/buefy";

--- a/src/components/OfficerCard.vue
+++ b/src/components/OfficerCard.vue
@@ -2,20 +2,14 @@
   <div class="card">
     <div class="card-image">
       <figure class="image is-4by3">
-        <img
-          src="https://bulma.io/images/placeholders/1280x960.png"
-          alt="Placeholder image"
-        />
+        <img :src="card.face" />
       </figure>
     </div>
     <div class="card-content">
       <div class="media">
         <div class="media-left">
           <figure class="image is-48x48">
-            <img
-              src="https://bulma.io/images/placeholders/96x96.png"
-              alt="Placeholder image"
-            />
+            <img :src="card.icon" />
           </figure>
         </div>
         <div class="media-content">

--- a/src/components/OfficerCard.vue
+++ b/src/components/OfficerCard.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="card">
+    <div class="card-image">
+      <figure class="image is-4by3">
+        <img
+          src="https://bulma.io/images/placeholders/1280x960.png"
+          alt="Placeholder image"
+        />
+      </figure>
+    </div>
+    <div class="card-content">
+      <div class="media">
+        <div class="media-left">
+          <figure class="image is-48x48">
+            <img
+              src="https://bulma.io/images/placeholders/96x96.png"
+              alt="Placeholder image"
+            />
+          </figure>
+        </div>
+        <div class="media-content">
+          <p class="title is-4">{{ card.name }}</p>
+          <p class="subtitle is-6">@{{ card.handle }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "OfficerCard",
+  props: {
+    card: Object
+  }
+};
+</script>

--- a/src/components/OfficerCardSet.vue
+++ b/src/components/OfficerCardSet.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    <div class="columns is-centered">
+      <div v-for="card in roleCheck" :key="card.id" :class="columnType">
+        <OfficerCard :card="card" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import OfficerCard from "./OfficerCard";
+
+export default {
+  name: "OfficerCardSet",
+  components: {
+    OfficerCard
+  },
+  props: {
+    cards: Array,
+    roleWanted: String,
+    doubleSet: Boolean
+  },
+  computed: {
+    roleCheck: function() {
+      return this.cards.filter(card => {
+        return card.role.includes(this.roleWanted);
+      });
+    },
+    columnType: function() {
+      if (this.doubleSet) {
+        return "column is-half";
+      }
+      return "column is-3";
+    }
+  }
+};
+</script>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -42,9 +42,21 @@
           <g-link class="navbar-item" to="/docs">
             Documentation
           </g-link>
-          <g-link class="navbar-item" to="/about">
-            About
-          </g-link>
+          <div class="navbar-item has-dropdown is-hoverable">
+            <div class="navbar-link">
+              About
+            </div>
+            <div class="navbar-dropdown is-boxed">
+              <g-link
+                v-for="(about_item, index) in about"
+                :key="index"
+                :to="about_item.route"
+                class="navbar-item"
+              >
+                {{ about_item.name }}
+              </g-link>
+            </div>
+          </div>
           <g-link class="navbar-item" to="/docs/internal/contact">
             Contact Us
           </g-link>
@@ -129,6 +141,10 @@ export default {
         { name: "MySQL Database", route: "/docs/services/mysql" },
         { name: "Software Mirrors", route: "/docs/services/mirrors" },
         { name: "High Performance Computing", route: "/docs/services/hpc" }
+      ],
+      about: [
+        { name: "What We Do", route: "/about" },
+        { name: "Officers", route: "/about/officers" }
       ]
     };
   },

--- a/src/pages/About/Officers.vue
+++ b/src/pages/About/Officers.vue
@@ -124,67 +124,89 @@ export default {
         id: 1,
         name: "Kevin Mo",
         handle: "kmo",
-        role: ["General Manager"]
+        role: ["General Manager"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 2,
         name: "Saurabh Narain ",
         handle: "snarain",
-        role: ["General Manager"]
+        role: ["General Manager"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 3,
         name: "Nikhil Jha  ",
         handle: "njha",
-        role: ["Site Manager"]
+        role: ["Site Manager"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 4,
         name: "Frank Dai",
         handle: "fydai",
-        role: ["Site Manager"]
+        role: ["Site Manager"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 5,
         name: "Ja Wattanawong",
         handle: "jaw",
-        role: ["Internal Head"]
+        role: ["Internal Head"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 6,
         name: "Ronit Nath",
         handle: "ronitnath",
-        role: ["Internal Head", "Finance Head", "Communications Head"]
+        role: ["Internal Head", "Finance Head", "Communications Head"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 7,
         name: "Ryan-chan",
         handle: "rrchan",
-        role: ["Industry and Alumni Relations Head"]
+        role: ["Industry and Alumni Relations Head"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 8,
         name: "Andrew Aikawa",
         handle: "asai",
-        role: ["Industry and Alumni Relations Head"]
+        role: ["Industry and Alumni Relations Head"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 9,
         name: "Nicholas Berberi",
         handle: "ncberberi",
-        role: ["Finance Head"]
+        role: ["Finance Head"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 10,
         name: "Ben Cuan",
         handle: "bencuan",
-        role: ["Communications Head", "DeCal Head"]
+        role: ["Communications Head", "DeCal Head"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       },
       {
         id: 11,
         name: "Leo Huang",
         handle: "hexhu",
-        role: ["DeCal Head"]
+        role: ["DeCal Head"],
+        face: "https://bulma.io/images/placeholders/1280x960.png",
+        icon: "https://bulma.io/images/placeholders/96x96.png"
       }
     ];
   }

--- a/src/pages/About/Officers.vue
+++ b/src/pages/About/Officers.vue
@@ -4,29 +4,14 @@
       <div class="container">
         <h1 class="title is-1 has-text-centered">Meet Our Officers</h1>
         <div class="is-divider"></div>
-        <h2 class="title is-2 has-text-centered">Faculty Adviser</h2>
-        <h4 class="title is-4 has-text-centered">
-          <a href="https://www.cs.berkeley.edu/~bh">Dr. Brian Harvey</a>
-        </h4>
-
-        <h2 class="title is-2 has-text-centered">Board of Directors</h2>
-        <h4 class="title is-4 has-text-centered">
-          See <a href="https://www.ocf.berkeley.edu/~staff/bod/">minutes</a> for
-          attendance
-        </h4>
-        <h4 class="title is-4 has-text-centered">
-          The Board of Directors is the decision-making entity behind the OCF's
-          operations. The Board is appointed based on attendance at our
-          <a href="/about">weekly meetings</a>
-        </h4>
-        <div class="is-divider"></div>
 
         <h2 class="title is-2 has-text-centered">General Managers</h2>
-        <h4 class="title is-4 has-text-centered">
+        <p class="is-size-4 has-text-centered">
           General Managers handle the organizational activities of the OCF and
           lead the Board of Directors meetings. They are elected by the Board of
           Directors at the end of each semester.
-        </h4>
+        </p>
+        <br />
         <OfficerCardSet
           role-wanted="General Manager"
           :cards="cards"
@@ -36,11 +21,12 @@
         <div class="is-divider"></div>
 
         <h2 class="title is-2 has-text-centered">Site Managers</h2>
-        <h4 class="title is-4 has-text-centered">
+        <p class="is-size-4 has-text-centered">
           Site Managers lie behind the technical work involved in maintaining
           the OCF lab and other services. They are elected by the Board of
           Directors at the end of each semester.
-        </h4>
+        </p>
+        <br />
         <OfficerCardSet
           role-wanted="Site Manager"
           :cards="cards"
@@ -49,10 +35,11 @@
         <br />
         <div class="is-divider"></div>
         <h2 class="title is-2 has-text-centered">Committee Heads</h2>
-        <h4 class="title is-4 has-text-centered">
+        <p class="is-size-4 has-text-centered">
           Committee heads guide the work of the various committees that function
           within the OCF.
-        </h4>
+        </p>
+        <br />
 
         <div class="columns is-centered">
           <div class="column">
@@ -92,12 +79,31 @@
             />
           </div>
         </div>
-        <h3 class="title is-3 has-text-centered">DeCal Heads</h3>
-        <OfficerCardSet
-          role-wanted="DeCal Head"
-          :cards="cards"
-          :double-set="false"
-        />
+        <div class="column">
+          <h3 class="title is-3 has-text-centered">DeCal Heads</h3>
+          <OfficerCardSet
+            role-wanted="DeCal Head"
+            :cards="cards"
+            :double-set="false"
+          />
+        </div>
+        <div class="is-divider"></div>
+
+        <h2 class="title is-2 has-text-centered">Faculty Adviser</h2>
+        <h4 class="title is-4 has-text-centered">
+          <a href="https://www.cs.berkeley.edu/~bh">Dr. Brian Harvey</a>
+        </h4>
+
+        <h2 class="title is-2 has-text-centered">Board of Directors</h2>
+        <p class="is-size-4 has-text-centered">
+          See <a href="https://www.ocf.berkeley.edu/~staff/bod/">minutes</a> for
+          attendance
+        </p>
+        <p class="is-size-4 has-text-centered">
+          The Board of Directors is the decision-making entity behind the OCF's
+          operations. The Board is appointed based on attendance at our
+          <a href="/about">weekly meetings</a>
+        </p>
       </div>
     </section>
   </Layout>

--- a/src/pages/About/Officers.vue
+++ b/src/pages/About/Officers.vue
@@ -2,166 +2,191 @@
   <Layout>
     <section class="section">
       <div class="container">
-        <div class="content">
-          <h1 class="title is-1">
-            About Us
-          </h1>
-          <div class="columns is-8 is-variable">
-            <div class="column is-half">
-              <h2 class="subtitle">What We Do</h2>
-              <p class="is-size-5">
-                We're a student organization dedicated to providing free
-                computing for all UC Berkeley students, faculty, and staff. We
-                run a super awesome computer lab on southside, have a wicked set
-                of servers for staff to play on, and provide cool services to
-                the Berkeley community.
-              </p>
-            </div>
-            <div class="column is-half">
-              <h2 class="subtitle">
-                Staff Meetings
-              </h2>
-              <p class="is-size-5">
-                OCF Staff meet to discuss technology, learn from each other, and
-                work on OCF projects. Drop-in visitors are always welcome,
-                especially those interested in joining the staff team!
-              </p>
-              <p class="is-size-4">
-                <strong>When:</strong> Every Monday at 8:10pm
-              </p>
-              <p class="is-size-4">
-                <strong>Where: </strong>
-                <a href="https://ocf.io/meet">Google Meet</a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-    <div class="is-divider"></div>
-    <section class="section">
-      <div class="container">
-        <div class="columns is-vcentered reverse-row-order">
-          <div class="column is-half">
-            <transition name="fade" mode="out-in">
-              <img
-                :key="servicesImages[servicesActiveImage]"
-                :src="servicesImages[servicesActiveImage]"
-                data-toggle="tooltip"
-                width="800"
-                height="600"
-                data-placement="bottom"
-                title="goTop"
-                alt=""
-              />
-            </transition>
-          </div>
-          <div class="column is-half">
-            <div class="columns is-centered is-vcentered">
-              <div class="column is-three-quarters">
-                <div class="content">
-                  <h2 class="title is-2 has-text-centered">
-                    Services We Provide
-                  </h2>
+        <h1 class="title is-1 has-text-centered">Meet Our Officers</h1>
+        <div class="is-divider"></div>
+        <h2 class="title is-2 has-text-centered">Faculty Adviser</h2>
+        <h4 class="title is-4 has-text-centered">
+          <a href="https://www.cs.berkeley.edu/~bh">Dr. Brian Harvey</a>
+        </h4>
 
-                  <p
-                    class="button card box is-white is-medium"
-                    :class="{ 'active-card': servicesActiveImage === 0 }"
-                    @click="servicesActiveImage = 0"
-                  >
-                    Web &amp; Email Hosting
-                  </p>
-                  <p
-                    class="button card box is-white is-medium"
-                    :class="{ 'active-card': servicesActiveImage === 1 }"
-                    @click="servicesActiveImage = 1"
-                  >
-                    UNIX Shell Accounts
-                  </p>
-                  <p
-                    class="button card box is-white is-medium"
-                    :class="{ 'active-card': servicesActiveImage === 2 }"
-                    @click="servicesActiveImage = 2"
-                  >
-                    Free Printing for Members
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-    <div class="is-divider"></div>
-    <section class="section">
-      <div class="container">
-        <div class="columns is-vcentered">
-          <div class="column is-half">
-            <g-image
-              src="~/assets/penguins_placeholder.jpg"
-              width="800"
-              height="600"
+        <h2 class="title is-2 has-text-centered">Board of Directors</h2>
+        <h4 class="title is-4 has-text-centered">
+          See <a href="https://www.ocf.berkeley.edu/~staff/bod/">minutes</a> for
+          attendance
+        </h4>
+        <h4 class="title is-4 has-text-centered">
+          The Board of Directors is the decision-making entity behind the OCF's
+          operations. The Board is appointed based on attendance at our
+          <a href="/about">weekly meetings</a>
+        </h4>
+        <div class="is-divider"></div>
+
+        <h2 class="title is-2 has-text-centered">General Managers</h2>
+        <h4 class="title is-4 has-text-centered">
+          General Managers handle the organizational activities of the OCF and
+          lead the Board of Directors meetings. They are elected by the Board of
+          Directors at the end of each semester.
+        </h4>
+        <OfficerCardSet
+          role-wanted="General Manager"
+          :cards="cards"
+          :double-set="false"
+        />
+        <br />
+        <div class="is-divider"></div>
+
+        <h2 class="title is-2 has-text-centered">Site Managers</h2>
+        <h4 class="title is-4 has-text-centered">
+          Site Managers lie behind the technical work involved in maintaining
+          the OCF lab and other services. They are elected by the Board of
+          Directors at the end of each semester.
+        </h4>
+        <OfficerCardSet
+          role-wanted="Site Manager"
+          :cards="cards"
+          :double-set="false"
+        />
+        <br />
+        <div class="is-divider"></div>
+        <h2 class="title is-2 has-text-centered">Committee Heads</h2>
+        <h4 class="title is-4 has-text-centered">
+          Committee heads guide the work of the various committees that function
+          within the OCF.
+        </h4>
+
+        <div class="columns is-centered">
+          <div class="column">
+            <h3 class="title is-3 has-text-centered">Internal Heads</h3>
+            <OfficerCardSet
+              role-wanted="Internal Head"
+              :cards="cards"
+              :double-set="true"
             />
           </div>
-          <div class="column is-half">
-            <div class="columns is-centered is-vcentered">
-              <div class="column is-three-quarters">
-                <h2 class="title is-2 has-text-centered">
-                  Joining the OCF is an awesome way to learn!
-                </h2>
-                <h4 class="title is-4">
-                  We love talking tech and learning new things.
-                </h4>
-                <p>
-                  We use our weekly board meetings and staff hours not just to
-                  make decisions, but also to learn more about *nix and free
-                  software.
-                </p>
-                <h4 class="title is-4">
-                  We're totally open and super-inclusive!
-                </h4>
-                <p>
-                  Our members have a wide range of majors and technical
-                  backgrounds. There are tons of ways to learn and have fun!
-                </p>
-              </div>
-            </div>
+          <div class="column">
+            <h3 class="title is-3 has-text-centered">
+              Industry and Alumni Relations Heads
+            </h3>
+            <OfficerCardSet
+              role-wanted="Industry and Alumni Relations Head"
+              :cards="cards"
+              :double-set="true"
+            />
           </div>
         </div>
-      </div>
-    </section>
-    <div class="is-divider"></div>
-    <!--- The timeline -->
-
-    <section class="section has-text-centered">
-      <div class="container">
-        <h1 class="title">
-          History
-        </h1>
-        <history />
+        <div class="columns is-centered">
+          <div class="column">
+            <h3 class="title is-3 has-text-centered">Finance Heads</h3>
+            <OfficerCardSet
+              role-wanted="Finance Head"
+              :cards="cards"
+              :double-set="true"
+            />
+          </div>
+          <div class="column">
+            <h3 class="title is-3 has-text-centered">Communications Heads</h3>
+            <OfficerCardSet
+              role-wanted="Communications Head"
+              :cards="cards"
+              :double-set="true"
+            />
+          </div>
+        </div>
+        <h3 class="title is-3 has-text-centered">DeCal Heads</h3>
+        <OfficerCardSet
+          role-wanted="DeCal Head"
+          :cards="cards"
+          :double-set="false"
+        />
       </div>
     </section>
   </Layout>
 </template>
 
 <script>
-import History from "~/components/History.vue";
+import OfficerCardSet from "../../components/OfficerCardSet";
+
 export default {
   metaInfo: {
-    title: "About Us"
+    title: "Officers"
   },
   components: {
-    History
+    OfficerCardSet
   },
   data() {
     return {
-      servicesActiveImage: 0,
-      servicesImages: [
-        "/assets/img/cloud.jpg",
-        "/assets/img/unix-shell.jpg",
-        "/assets/img/printer.jpg"
-      ]
+      cards: []
     };
+  },
+  created() {
+    this.cards = [
+      {
+        id: 1,
+        name: "Kevin Mo",
+        handle: "kmo",
+        role: ["General Manager"]
+      },
+      {
+        id: 2,
+        name: "Saurabh Narain ",
+        handle: "snarain",
+        role: ["General Manager"]
+      },
+      {
+        id: 3,
+        name: "Nikhil Jha  ",
+        handle: "njha",
+        role: ["Site Manager"]
+      },
+      {
+        id: 4,
+        name: "Frank Dai",
+        handle: "fydai",
+        role: ["Site Manager"]
+      },
+      {
+        id: 5,
+        name: "Ja Wattanawong",
+        handle: "jaw",
+        role: ["Internal Head"]
+      },
+      {
+        id: 6,
+        name: "Ronit Nath",
+        handle: "ronitnath",
+        role: ["Internal Head", "Finance Head", "Communications Head"]
+      },
+      {
+        id: 7,
+        name: "Ryan-chan",
+        handle: "rrchan",
+        role: ["Industry and Alumni Relations Head"]
+      },
+      {
+        id: 8,
+        name: "Andrew Aikawa",
+        handle: "asai",
+        role: ["Industry and Alumni Relations Head"]
+      },
+      {
+        id: 9,
+        name: "Nicholas Berberi",
+        handle: "ncberberi",
+        role: ["Finance Head"]
+      },
+      {
+        id: 10,
+        name: "Ben Cuan",
+        handle: "bencuan",
+        role: ["Communications Head", "DeCal Head"]
+      },
+      {
+        id: 11,
+        name: "Leo Huang",
+        handle: "hexhu",
+        role: ["DeCal Head"]
+      }
+    ];
   }
 };
 </script>

--- a/src/pages/About/Officers.vue
+++ b/src/pages/About/Officers.vue
@@ -45,8 +45,8 @@
           <div class="column is-half">
             <transition name="fade" mode="out-in">
               <img
-                :src="servicesImages[servicesActiveImage]"
                 :key="servicesImages[servicesActiveImage]"
+                :src="servicesImages[servicesActiveImage]"
                 data-toggle="tooltip"
                 width="800"
                 height="600"
@@ -66,22 +66,22 @@
 
                   <p
                     class="button card box is-white is-medium"
-                    @click="servicesActiveImage = 0"
                     :class="{ 'active-card': servicesActiveImage === 0 }"
+                    @click="servicesActiveImage = 0"
                   >
                     Web &amp; Email Hosting
                   </p>
                   <p
                     class="button card box is-white is-medium"
-                    @click="servicesActiveImage = 1"
                     :class="{ 'active-card': servicesActiveImage === 1 }"
+                    @click="servicesActiveImage = 1"
                   >
                     UNIX Shell Accounts
                   </p>
                   <p
                     class="button card box is-white is-medium"
-                    @click="servicesActiveImage = 2"
                     :class="{ 'active-card': servicesActiveImage === 2 }"
+                    @click="servicesActiveImage = 2"
                   >
                     Free Printing for Members
                   </p>

--- a/src/pages/About/index.vue
+++ b/src/pages/About/index.vue
@@ -1,0 +1,179 @@
+<template>
+  <Layout>
+    <section class="section">
+      <div class="container">
+        <div class="content">
+          <h1 class="title is-1">
+            About Us
+          </h1>
+          <div class="columns is-8 is-variable">
+            <div class="column is-half">
+              <h2 class="subtitle">What We Do</h2>
+              <p class="is-size-5">
+                We're a student organization dedicated to providing free
+                computing for all UC Berkeley students, faculty, and staff. We
+                run a super awesome computer lab on southside, have a wicked set
+                of servers for staff to play on, and provide cool services to
+                the Berkeley community.
+              </p>
+            </div>
+            <div class="column is-half">
+              <h2 class="subtitle">
+                Staff Meetings
+              </h2>
+              <p class="is-size-5">
+                OCF Staff meet to discuss technology, learn from each other, and
+                work on OCF projects. Drop-in visitors are always welcome,
+                especially those interested in joining the staff team!
+              </p>
+              <p class="is-size-4">
+                <strong>When:</strong> Every Monday at 8:10pm
+              </p>
+              <p class="is-size-4">
+                <strong>Where: </strong>
+                <a href="https://ocf.io/meet">Google Meet</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <div class="is-divider"></div>
+    <section class="section">
+      <div class="container">
+        <div class="columns is-vcentered reverse-row-order">
+          <div class="column is-half">
+            <transition name="fade" mode="out-in">
+              <img
+                :key="servicesImages[servicesActiveImage]"
+                :src="servicesImages[servicesActiveImage]"
+                data-toggle="tooltip"
+                width="800"
+                height="600"
+                data-placement="bottom"
+                title="goTop"
+                alt=""
+              />
+            </transition>
+          </div>
+          <div class="column is-half">
+            <div class="columns is-centered is-vcentered">
+              <div class="column is-three-quarters">
+                <div class="content">
+                  <h2 class="title is-2 has-text-centered">
+                    Services We Provide
+                  </h2>
+
+                  <p
+                    class="button card box is-white is-medium"
+                    :class="{ 'active-card': servicesActiveImage === 0 }"
+                    @click="servicesActiveImage = 0"
+                  >
+                    Web &amp; Email Hosting
+                  </p>
+                  <p
+                    class="button card box is-white is-medium"
+                    :class="{ 'active-card': servicesActiveImage === 1 }"
+                    @click="servicesActiveImage = 1"
+                  >
+                    UNIX Shell Accounts
+                  </p>
+                  <p
+                    class="button card box is-white is-medium"
+                    :class="{ 'active-card': servicesActiveImage === 2 }"
+                    @click="servicesActiveImage = 2"
+                  >
+                    Free Printing for Members
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <div class="is-divider"></div>
+    <section class="section">
+      <div class="container">
+        <div class="columns is-vcentered">
+          <div class="column is-half">
+            <g-image
+              src="~/assets/penguins_placeholder.jpg"
+              width="800"
+              height="600"
+            />
+          </div>
+          <div class="column is-half">
+            <div class="columns is-centered is-vcentered">
+              <div class="column is-three-quarters">
+                <h2 class="title is-2 has-text-centered">
+                  Joining the OCF is an awesome way to learn!
+                </h2>
+                <h4 class="title is-4">
+                  We love talking tech and learning new things.
+                </h4>
+                <p>
+                  We use our weekly board meetings and staff hours not just to
+                  make decisions, but also to learn more about *nix and free
+                  software.
+                </p>
+                <h4 class="title is-4">
+                  We're totally open and super-inclusive!
+                </h4>
+                <p>
+                  Our members have a wide range of majors and technical
+                  backgrounds. There are tons of ways to learn and have fun!
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <div class="is-divider"></div>
+    <!--- The timeline -->
+
+    <section class="section has-text-centered">
+      <div class="container">
+        <h1 class="title">
+          History
+        </h1>
+        <history />
+      </div>
+    </section>
+  </Layout>
+</template>
+
+<script>
+import History from "~/components/History.vue";
+export default {
+  metaInfo: {
+    title: "About Us"
+  },
+  components: {
+    History
+  },
+  data() {
+    return {
+      servicesActiveImage: 0,
+      servicesImages: [
+        "/assets/img/cloud.jpg",
+        "/assets/img/unix-shell.jpg",
+        "/assets/img/printer.jpg"
+      ]
+    };
+  }
+};
+</script>
+<style scoped>
+p.card {
+  transition: transform 0.6s;
+  width: 100%;
+}
+.active-card {
+  transform: translateX(1.75em);
+}
+.reverse-row-order {
+  flex-direction: row-reverse;
+}
+</style>

--- a/src/pages/About/index.vue
+++ b/src/pages/About/index.vue
@@ -3,9 +3,7 @@
     <section class="section">
       <div class="container">
         <div class="content">
-          <h1 class="title is-1">
-            About Us
-          </h1>
+          <h1 class="title is-1">About Us</h1>
           <div class="columns is-8 is-variable">
             <div class="column is-half">
               <h2 class="subtitle">What We Do</h2>
@@ -18,9 +16,7 @@
               </p>
             </div>
             <div class="column is-half">
-              <h2 class="subtitle">
-                Staff Meetings
-              </h2>
+              <h2 class="subtitle">Staff Meetings</h2>
               <p class="is-size-5">
                 OCF Staff meet to discuss technology, learn from each other, and
                 work on OCF projects. Drop-in visitors are always welcome,
@@ -135,9 +131,7 @@
 
     <section class="section has-text-centered">
       <div class="container">
-        <h1 class="title">
-          History
-        </h1>
+        <h1 class="title">History</h1>
         <history />
       </div>
     </section>


### PR DESCRIPTION
Ported over the officers page (https://www.ocf.berkeley.edu/docs/about/officers/) from the old website to the new. I used a card based layout that I've seen several other clubs/organizations use. Hopefully the officers are okay with sharing their faces.

The Previous officers section is not implemented yet. I am not familiar with the old website, and when I looked at the old website, I couldn't figure out where the previous officers were stored. 

Currently, the officers are hardcoded in. It would probably be a good idea to store them in some other sort of file.
Let me know if there is anything else that should be done, or if you have any suggestions!