### PR TITLE
Enable sourcemaps for production debugging

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -7,6 +7,9 @@
 module.exports = {
   siteName: "Open Computing Facility",
   siteUrl: "ocf.berkeley.edu",
+  configureWebpack: {
+    devtool: "source-map"
+  },
   chainWebpack: config => {
     const svgRule = config.module.rule("svg");
     svgRule.uses.clear();


### PR DESCRIPTION
Can we at least experimentally enable sourcemaps so we can debug the problem with navigation on the site? This may break the website according to https://github.com/gridsome/gridsome/issues/975 but it may also work. 