### PR TITLE
fix navigation not working from homepage

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -89,8 +89,8 @@
               ></g-image>
               <p class="title">Join Staff!</p>
               <p class="subtitle">
-                Meetings 8PM every Monday<!-- in the lab -->
-                at <a href="http://ocf.io/meet">ocf.io/meet</a>
+                Meetings 8PM every Monday at
+                <a href="http://ocf.io/meet">ocf.io/meet</a>
               </p>
               <div class="content">
                 <p>


### PR DESCRIPTION
Remove HTML comment in Vue template for `/`, since evidently the presence of a comment causes hydration of server-rendered content on the client to fail (silently). This caused the client to not mount correctly when loading SSR'd HTML from `/`, and thus break all `g-link` navigation.

Closes #210