### PR TITLE
Implemented officers-page#198, yet again

### DIFF
--- a/src/assets/officers-data/past-officers.json
+++ b/src/assets/officers-data/past-officers.json
@@ -1,0 +1,628 @@
+{
+  "pastOfficers": [
+    {
+      "term": "Spring 2021",
+      "gms": [
+        { "name": "Kevin Mo", "handle": "kmo" },
+        { "name": "Saurabh Narain", "handle": "snarain" }
+      ],
+      "sms": [
+        { "name": "Nikhil Jha", "handle": "njha" },
+        { "name": "Frank Dai", "handle": "fydai" }
+      ]
+    },
+    {
+      "term": "Fall 2020",
+      "gms": [
+        { "name": "Derek Phan", "handle": "dphan" },
+        { "name": "Kevin Mo", "handle": "kmo" }
+      ],
+      "sms": [
+        { "name": "Frank Dai", "handle": "fydai" },
+        { "name": "Ja (Thanakul) Wattanawong", "handle": "jaw" }
+      ]
+    },
+    {
+      "term": "Spring 2020",
+      "gms": [
+        { "name": "Derek Phan", "handle": "dphan" },
+        { "name": "Bernard Zhao", "handle": "bernardzhao" }
+      ],
+      "sms": [
+        { "name": "Christopher Cooper", "handle": "cooperc" },
+        { "name": "Ja (Thanakul) Wattanawong", "handle": "jaw" }
+      ]
+    },
+    {
+      "term": "Fall 2019",
+      "gms": [
+        { "name": "Christopher Cooper", "handle": "cooperc" },
+        { "name": "Patricia Hanus", "handle": "php" }
+      ],
+      "sms": [
+        { "name": "Ethan Smith (05/18/19–11/18/19)", "handle": "ethanhs" },
+        { "name": "Frank Dai", "handle": "fydai" }
+      ]
+    },
+    {
+      "term": "Spring 2019",
+      "gms": [
+        { "name": "Abizer Lokhandwala", "handle": "abizer" },
+        { "name": "Alexander Byron Welty", "handle": "awelty" }
+      ],
+      "gmsDeputies": [{ "name": "Andrew Aikawa", "handle": "asai" }],
+      "sms": [
+        { "name": "Benjamin Zhang", "handle": "bzh" },
+        { "name": "Daniel Kessler", "handle": "dkessler" }
+      ],
+      "smsDeputies": [
+        { "name": "Ethan Smith", "handle": "ethanhs" },
+        { "name": "Christopher Cooper", "handle": "cooperc" }
+      ]
+    },
+    {
+      "term": "Fall 2018",
+      "gms": [
+        { "name": "Andrew Aikawa (05/12/18–11/07/18)", "handle": "asai" },
+        {
+          "name": "Alexander Byron Welty (acting) (11/07/18–11/26/18)",
+          "handle": "awelty"
+        },
+        { "name": "Tony Liu (acting) (11/07/18–11/26/18)", "handle": "trliu" },
+        {
+          "name": "Alexander Byron Welty (11/26/18–12/14/18)",
+          "handle": "awelty"
+        },
+        { "name": "Tony Liu (11/26/18–12/14/18)", "handle": "trliu" }
+      ],
+      "sms": [
+        { "name": "Daniel Kessler", "handle": "dkessler" },
+        { "name": "Kevin Kuehler", "handle": "keur" }
+      ]
+    },
+    {
+      "term": "Spring 2018",
+      "gms": [{ "name": "Sahil Hasan", "handle": "shasan" }],
+      "gmsDeputies": [
+        { "name": "Andrew Aikawa", "handle": "asai" },
+        { "name": "Alexander Byron Welty", "handle": "awelty" },
+        { "name": "Brian Sang", "handle": "baisang" }
+      ],
+      "sms": [
+        { "name": "Jason Perrin", "handle": "jvperrin" },
+        { "name": "Abizer Lokhandwala", "handle": "abizer" }
+      ],
+      "smsDeputies": [
+        { "name": "Daniel Kessler", "handle": "dkessler" },
+        { "name": "Harrison Kuo", "handle": "kuoh" }
+      ]
+    },
+    {
+      "term": "Fall 2017",
+      "gms": [
+        { "name": "Brian Sang", "handle": "baisang" },
+        { "name": "Sahil Hasan", "handle": "shasan" }
+      ],
+      "gmsDeputies": [{ "name": "Andrew Aikawa", "handle": "asai" }],
+      "sms": [
+        { "name": "Jason Perrin", "handle": "jvperrin" },
+        { "name": "Abizer Lokhandwala", "handle": "abizer" }
+      ],
+      "smsDeputies": [
+        { "name": "Daniel Kessler", "handle": "dkessler" },
+        { "name": "Harrison Kuo", "handle": "kuoh" }
+      ]
+    },
+    {
+      "term": "Spring 2017",
+      "gms": [
+        { "name": "Nick Impicciche", "handle": "nickimp" },
+        { "name": "Brian Sang", "handle": "baisang" }
+      ],
+      "gmsDeputies": [{ "name": "Sahil Hasan", "handle": "shasan" }],
+      "sms": [
+        { "name": "Jason Perrin", "handle": "jvperrin" },
+        { "name": "Matthew McAllister", "handle": "mattmcal" }
+      ],
+      "smsDeputies": [{ "name": "Kevin Peng", "handle": "kpengboy" }]
+    },
+    {
+      "term": "Fall 2016",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "gmsDeputies": [
+        { "name": "Brian Sang (09/26/16–11/28/16)", "handle": "baisang" },
+        { "name": "Sahil Hasan (10/24/16–11/28/16)", "handle": "shasan" }
+      ],
+      "sms": [
+        { "name": "Jason Perrin", "handle": "jvperrin" },
+        { "name": "Matthew McAllister", "handle": "mattmcal" }
+      ]
+    },
+    {
+      "term": "Summer 2016",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [
+        { "name": "Jason Perrin", "handle": "jvperrin" },
+        { "name": "Matthew McAllister", "handle": "mattmcal" }
+      ]
+    },
+    {
+      "term": "Spring 2016",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [
+        { "name": "Jason Perrin", "handle": "jvperrin" },
+        { "name": "Matthew McAllister", "handle": "mattmcal" }
+      ]
+    },
+    {
+      "term": "Fall 2015",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [{ "name": "Chris Kuehl", "handle": "ckuehl" }]
+    },
+    {
+      "term": "Summer 2015",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [{ "name": "Chris Kuehl", "handle": "ckuehl" }]
+    },
+    {
+      "term": "Spring 2015",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [{ "name": "Chris Kuehl", "handle": "ckuehl" }]
+    },
+    {
+      "term": "Fall 2014",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [{ "name": "Chris Kuehl", "handle": "ckuehl" }]
+    },
+    {
+      "term": "Summer 2014",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [{ "name": "Chris Kuehl", "handle": "ckuehl" }]
+    },
+    {
+      "term": "Spring 2014",
+      "gms": [{ "name": "Nick Impicciche", "handle": "nickimp" }],
+      "sms": [{ "name": "Chris Kuehl", "handle": "ckuehl" }]
+    },
+    {
+      "term": "Fall 2013",
+      "gms": [{ "name": "Dara Adib", "handle": "daradib" }],
+      "sms": [{ "name": "Timmy Zhu", "handle": "tzhu" }]
+    },
+    {
+      "term": "Summer 2013",
+      "gms": [{ "name": "Dara Adib", "handle": "daradib" }],
+      "sms": [{ "name": "Timmy Zhu", "handle": "tzhu" }]
+    },
+    {
+      "term": "Spring 2013",
+      "gms": [{ "name": "Dara Adib", "handle": "daradib" }],
+      "sms": [
+        { "name": "Timmy Zhu", "handle": "tzhu" },
+        { "name": "Felix Andy Wong", "handle": "waf" }
+      ]
+    },
+    {
+      "term": "Fall 2012",
+      "gms": [{ "name": "Dara Adib", "handle": "daradib" }],
+      "sms": [
+        { "name": "Timmy Zhu", "handle": "tzhu" },
+        { "name": "Sanjay Krishnan", "handle": "sanjayk" }
+      ]
+    },
+    {
+      "term": "Summer 2012",
+      "gms": [{ "name": "Dara Adib", "handle": "daradib" }],
+      "sms": [{ "name": "Felix Andy Wong", "handle": "waf" }]
+    },
+    {
+      "term": "Spring 2012",
+      "gms": [
+        { "name": "Dara Adib", "handle": "daradib" },
+        { "name": "Loren Patrick McIntyre", "handle": "mcint" }
+      ],
+      "sms": [
+        { "name": "Felix Andy Wong", "handle": "waf" },
+        { "name": "Kenneth Hui Do", "handle": "kedo" }
+      ]
+    },
+    {
+      "term": "Fall 2011",
+      "gms": [{ "name": "Dara Adib", "handle": "daradib" }],
+      "sms": [
+        { "name": "Felix Andy Wong", "handle": "waf" },
+        { "name": "Kenneth Hui Do", "handle": "kedo" }
+      ]
+    },
+    {
+      "term": "Summer 2011",
+      "gms": [{ "name": "Sherry Ann Gong", "handle": "sherryg" }],
+      "sms": [
+        { "name": "Dara Adib", "handle": "daradib" },
+        { "name": "Benjamin Eugene Ortiz", "handle": "benortiz" }
+      ]
+    },
+    {
+      "term": "Spring 2011",
+      "gms": [{ "name": "Sherry Ann Gong", "handle": "sherryg" }],
+      "sms": [
+        { "name": "Dara Adib", "handle": "daradib" },
+        { "name": "Benjamin Eugene Ortiz", "handle": "benortiz" }
+      ]
+    },
+    {
+      "term": "Fall 2010",
+      "gms": [
+        { "name": "Sherry Ann Gong", "handle": "sherryg" },
+        { "name": "Huy The Doan", "handle": "simplyhd" }
+      ],
+      "sms": [
+        { "name": "Sanjay Krishnan", "handle": "sanjayk" },
+        { "name": "Felix Andy Wong", "handle": "waf" }
+      ]
+    },
+    {
+      "term": "Spring 2010",
+      "gms": [{ "name": "Michael Shimei Gasidlo", "handle": "mgasidlo" }],
+      "sms": [
+        { "name": "Sanjay Krishnan", "handle": "sanjayk" },
+        { "name": "Alan Wong", "handle": "alanw" }
+      ]
+    },
+    {
+      "term": "Fall 2009",
+      "gms": [{ "name": "Michael Shimei Gasidlo", "handle": "mgasidlo" }],
+      "sms": [
+        { "name": "Sanjay Krishnan", "handle": "sanjayk" },
+        { "name": "Alan Wong", "handle": "alanw" }
+      ]
+    },
+    {
+      "term": "Spring 2009",
+      "gms": [{ "name": "Genevieve C Wong", "handle": "gcwong" }],
+      "sms": [
+        { "name": "Michael Shimei Gasidlo", "handle": "mgasidlo" },
+        { "name": "Jameson J Lee", "handle": "jameson" }
+      ]
+    },
+    {
+      "term": "Fall 2008",
+      "gms": [{ "name": "Genevieve C Wong", "handle": "gcwong" }],
+      "sms": [
+        { "name": "Michael Shimei Gasidlo (milki)", "handle": "mgasidlo" },
+        { "name": "Jonathan Rich Chu", "handle": "jchu" }
+      ]
+    },
+    {
+      "term": "Spring 2008",
+      "gms": [{ "name": "Gordon Mei", "handle": "gordeon" }],
+      "sms": [{ "name": "Gregory Francis Shuflin", "handle": "gfs" }]
+    },
+    {
+      "term": "Fall 2007",
+      "gms": [{ "name": "Angel Kittiyachavalit", "handle": "akit" }],
+      "sms": [
+        { "name": "William Mallard (09/13/07–10/04/07)", "handle": "wjm" },
+        {
+          "name": "Steven Yuifai Luo (interim) (10/04/07–10/11/07) (milki)",
+          "handle": "sluo"
+        },
+        { "name": "Jonathan Rich Chu (10/11/07–02/07/08)", "handle": "jchu" }
+      ]
+    },
+    {
+      "term": "Spring 2007",
+      "gms": [
+        { "name": "Angel Kittiyachavalit", "handle": "akit" },
+        { "name": "Sue Hyun Ahnn", "handle": "sahnn" }
+      ],
+      "sms": [
+        { "name": "Aaron Oaks", "handle": "aoaks" },
+        { "name": "Elliot Block", "handle": "elliot" }
+      ]
+    },
+    {
+      "term": "Fall 2006",
+      "gms": [
+        { "name": "Thomson Van Nguyen", "handle": "thomson" },
+        { "name": "Angel Kittiyachavalit", "handle": "akit" }
+      ],
+      "sms": [
+        { "name": "Stephen Le", "handle": "sle" },
+        { "name": "Yury Arkady Sobolev", "handle": "yury" }
+      ]
+    },
+    {
+      "term": "Spring 2006",
+      "gms": [
+        { "name": "Toby Hocking", "handle": "tdhock" },
+        { "name": "Griffin Foster", "handle": "griffin" }
+      ],
+      "sms": [{ "name": "Steven Yuifai Luo", "handle": "sluo" }]
+    },
+    {
+      "term": "Fall 2005",
+      "gms": [{ "name": "Frank Joseph Cohen", "handle": "frank" }],
+      "sms": [{ "name": "Elliot Block", "handle": "elliot" }]
+    },
+    {
+      "term": "Spring 2005",
+      "gms": [
+        { "name": "Frank Joseph Cohen", "handle": "frank" },
+        { "name": "Brandon Jue", "handle": "brando" }
+      ],
+      "sms": [
+        { "name": "Jerjou Cheng", "handle": "jerjou" },
+        { "name": "Dmitriy Shirchenko", "handle": "dima" }
+      ]
+    },
+    {
+      "term": "Fall 2004",
+      "gms": [{ "name": "Eleen Chiang", "handle": "eleen" }],
+      "sms": [
+        { "name": "Jimmy Kittiyachavalit", "handle": "jkit" },
+        { "name": "George Wu", "handle": "geo" }
+      ]
+    },
+    {
+      "term": "Spring 2004",
+      "gms": [{ "name": "Eleen Chiang", "handle": "eleen" }],
+      "sms": [{ "name": "Jimmy Kittiyachavalit", "handle": "jkit" }]
+    },
+    {
+      "term": "Fall 2003",
+      "gms": [
+        { "name": "Jimmy Kittiyachavalit", "handle": "jkit" },
+        { "name": "Eleen Chiang", "handle": "eleen" }
+      ],
+      "sms": [
+        { "name": "Devin Jones", "handle": "jones" },
+        { "name": "Akop Pogosian", "handle": "akopps" }
+      ]
+    },
+    {
+      "term": "Spring 2003",
+      "gms": [
+        { "name": "Jeff Emrich", "handle": "jeffe" },
+        { "name": "Charles Patrick Feyh", "handle": "cpfeyh" }
+      ],
+      "sms": [
+        { "name": "Derek Chan", "handle": "dwc" },
+        { "name": "Randy Aoshi Chung", "handle": "aoshi" }
+      ]
+    },
+    {
+      "term": "Fall 2002",
+      "gms": [
+        { "name": "Emily Watt", "handle": "ewhatt" },
+        { "name": "Wayne Yu-Wing Chan", "handle": "wyc" }
+      ],
+      "sms": [
+        { "name": "Akop Pogosian", "handle": "akopps" },
+        { "name": "Derek Chan", "handle": "dwc" }
+      ]
+    },
+    {
+      "term": "Spring 2002",
+      "gms": [{ "name": "Stephen J. Callahan", "handle": "calman" }],
+      "sms": [
+        { "name": "Stephen McCamant", "handle": "smcc" },
+        { "name": "Wayne Yu-Wing Chan", "handle": "wyc" }
+      ]
+    },
+    {
+      "term": "Fall 2001",
+      "gms": [{ "name": "Gabriel Gonzalez", "handle": "gmg" }],
+      "sms": [
+        { "name": "Stephen McCamant", "handle": "smcc" },
+        { "name": "Bem Ajani Jones-Bey", "handle": "ajani" }
+      ]
+    },
+    {
+      "term": "Spring 2001",
+      "gms": [{ "name": "Gabriel Gonzalez", "handle": "gmg" }],
+      "sms": [
+        { "name": "Stephen McCamant", "handle": "smcc" },
+        { "name": "Akop Pogosian", "handle": "akopps" }
+      ]
+    },
+    {
+      "term": "Fall 2000",
+      "gms": [
+        { "name": "Charles Patrick Feyh", "handle": "cpfeyh" },
+        { "name": "Stephen McCamant", "handle": "smcc" }
+      ],
+      "sms": [{ "name": "Akop Pogosian", "handle": "akopps" }]
+    },
+    {
+      "term": "Spring 2000",
+      "gms": [{ "name": "Stephen McCamant", "handle": "smcc" }],
+      "sms": [{ "name": "Akop Pogosian", "handle": "akopps" }]
+    },
+    {
+      "term": "Fall 1999",
+      "gms": [
+        { "name": "Devin Jones", "handle": "jones" },
+        { "name": "Kenneth Ott", "handle": "kenao" }
+      ],
+      "sms": [
+        {
+          "name": "Katrina Templeton (09/08/99–11/17/99)",
+          "handle": "katster"
+        },
+        {
+          "name": "Akop Pogosian (interim) (11/17/99–01/31/00)",
+          "handle": "akopps"
+        }
+      ]
+    },
+    {
+      "term": "Summer 1999",
+      "gms": [{ "name": "Richard Dunn", "handle": "dunnthat" }],
+      "sms": [{ "name": "Katrina Templeton", "handle": "katster" }]
+    },
+    {
+      "term": "Spring 1999",
+      "gms": [{ "name": "Richard Dunn", "handle": "dunnthat" }],
+      "sms": [{ "name": "Katrina Templeton", "handle": "katster" }]
+    },
+    {
+      "term": "Fall 1998",
+      "gms": [{ "name": "Richard Dunn", "handle": "dunnthat" }],
+      "sms": [{ "name": "Katrina Templeton", "handle": "katster" }]
+    },
+    {
+      "term": "Summer 1998",
+      "gms": [{ "name": "Elaine Chao", "handle": "chaos" }],
+      "sms": [{ "name": "Luns Tee", "handle": "tee" }]
+    },
+    {
+      "term": "Spring 1998",
+      "gms": [{ "name": "Elaine Chao", "handle": "chaos" }],
+      "sms": [{ "name": "Ahilan Anantha", "handle": "ahilan" }]
+    },
+    {
+      "term": "Fall 1997",
+      "gms": [{ "name": "Rune Stromsness", "handle": "runes" }],
+      "sms": [{ "name": "Kenneth Nishimoto", "handle": "kennish" }]
+    },
+    {
+      "term": "Summer 1997",
+      "gms": [{ "name": "Elaine Chao", "handle": "chaos" }],
+      "sms": [{ "name": "Jennifer Coopersmith", "handle": "jenni" }]
+    },
+    {
+      "term": "Spring 1997",
+      "gms": [{ "name": "John W. Percival", "handle": "percival" }],
+      "sms": [{ "name": "Kenneth Nishimoto", "handle": "kennish" }]
+    },
+    {
+      "term": "Fall 1996",
+      "gms": [{ "name": "Alan Coopersmith", "handle": "alanc" }],
+      "sms": [{ "name": "Jennifer Coopersmith", "handle": "jenni" }]
+    },
+    {
+      "term": "Summer 1996",
+      "gms": [{ "name": "Elaine Chao", "handle": "chaos" }],
+      "sms": [{ "name": "Jennifer Coopersmith", "handle": "jenni" }]
+    },
+    {
+      "term": "Spring 1996",
+      "gms": [{ "name": "Elaine Chao", "handle": "chaos" }],
+      "sms": [{ "name": "Michael Constant", "handle": "mconst" }]
+    },
+    {
+      "term": "Fall 1995",
+      "gms": [{ "name": "Jennifer Coopersmith", "handle": "jenni" }],
+      "sms": [{ "name": "Erik Muller", "handle": "erikm" }]
+    },
+    {
+      "term": "Summer 1995",
+      "gms": [{ "name": "Jennifer Coopersmith", "handle": "jenni" }],
+      "sms": [{ "name": "Erik Muller", "handle": "erikm" }]
+    },
+    {
+      "term": "Spring 1995",
+      "gms": [{ "name": "Jennifer Coopersmith", "handle": "jenni" }],
+      "sms": [{ "name": "David Shih", "handle": "shyguy" }]
+    },
+    {
+      "term": "Fall 1994",
+      "gms": [{ "name": "Marco Nicosia", "handle": "marco" }],
+      "sms": [{ "name": "Alan Coopersmith", "handle": "alanc" }]
+    },
+    {
+      "term": "Summer 1994",
+      "gms": [
+        { "name": "Nevin Cheung", "handle": "nevman" },
+        { "name": "Keir Morgan", "handle": "kmorgan" }
+      ],
+      "sms": [{ "name": "Ari Zilka", "handle": "ari" }]
+    },
+    {
+      "term": "Spring 1994",
+      "gms": [{ "name": "Nevin Cheung", "handle": "nevman" }],
+      "sms": [{ "name": "Ari Zilka", "handle": "ari" }]
+    },
+    {
+      "term": "Fall 1993",
+      "gms": [{ "name": "Keir Morgan", "handle": "kmorgan" }],
+      "sms": [{ "name": "Lars Smith", "handle": "lars" }]
+    },
+    {
+      "term": "Spring 1993",
+      "gms": [{ "name": "Keir Morgan", "handle": "kmorgan" }],
+      "sms": [{ "name": "Marco Nicosia", "handle": "marco" }]
+    },
+    {
+      "term": "Fall 1992",
+      "gms": [
+        { "name": "E. Mark Ping (09/10/92–10/29/92)", "handle": "emarkp" },
+        {
+          "name": "David Paschich (interim) (10/29/92–11/12/92)",
+          "handle": "dpassage"
+        },
+        { "name": "Chris G. Demetriou (11/12/92–02/04/93)", "handle": "cgd" }
+      ],
+      "sms": [{ "name": "Keir Morgan", "handle": "kmorgan" }]
+    },
+    {
+      "term": "Summer 1992",
+      "gms": [{ "name": "David Friedman", "handle": "davidf" }],
+      "sms": [{ "name": "Marco Nicosia", "handle": "marco" }]
+    },
+    {
+      "term": "Spring 1992",
+      "gms": [{ "name": "Adam Richter", "handle": "adam" }],
+      "sms": [
+        { "name": "Roy S. Rapoport (02/06/92–04/16/92)", "handle": "rsr" },
+        {
+          "name": "Alan Coopersmith (interim) (04/16/92–04/23/92)",
+          "handle": "alanc"
+        },
+        { "name": "Roy S. Rapoport (04/23/92–09/10/92)", "handle": "rsr" }
+      ]
+    },
+    {
+      "term": "Fall 1991",
+      "gms": [{ "name": "George William Herbert", "handle": "gwh" }],
+      "sms": [{ "name": "Chris G. Demetriou", "handle": "cgd" }]
+    },
+    {
+      "term": "Spring 1991",
+      "gms": [{ "name": "Shannon Appel", "handle": "appel" }],
+      "sms": [{ "name": "David Paschich", "handle": "dpassage" }]
+    },
+    {
+      "term": "Fall 1990",
+      "gms": [{ "name": "Shannon Appel", "handle": "appel" }],
+      "sms": [{ "name": "Rob Menke", "handle": "rgm" }]
+    },
+    {
+      "term": "Summer 1990",
+      "gms": [{ "name": "Partha S. Banerjee", "handle": "psb" }],
+      "sms": [{ "name": "Adam Glass", "handle": "glass" }]
+    },
+    {
+      "term": "Spring 1990",
+      "gms": [{ "name": "Case Larsen", "handle": "ctl" }],
+      "sms": [{ "name": "Sam Shen", "handle": "sls" }]
+    },
+    {
+      "term": "Fall 1989",
+      "gms": [
+        { "name": "Partha S. Banerjee (11/14/89–03/21/90)", "handle": "psb" }
+      ],
+      "sms": [{ "name": "Case Larsen (11/14/89–03/21/90)", "handle": "ctl" }]
+    },
+    {
+      "term": "Spring 1989",
+      "gms": [
+        { "name": "Partha S. Banerjee (04/06/89–11/14/89)", "handle": "psb" }
+      ],
+      "sms": [
+        { "name": "Peter Shipley (04/06/89–11/14/89)", "handle": "shipley" }
+      ]
+    }
+  ]
+}

--- a/src/pages/About/Officers.vue
+++ b/src/pages/About/Officers.vue
@@ -104,6 +104,64 @@
           operations. The Board is appointed based on attendance at our
           <a href="/about">weekly meetings</a>
         </p>
+        <br />
+        <div class="is-divider"></div>
+
+        <h2 class="title is-2 has-text-centered">Previous Officers</h2>
+        <b-collapse
+          class="card has-background-light"
+          animation="slide"
+          :open="false"
+        >
+          <template #trigger="props">
+            <div class="card-header" role="button">
+              <p class="card-header-title">
+                View Past Officers
+              </p>
+              <a class="card-header-icon has-text-black">
+                <b-icon :icon="props.open ? 'menu-up' : 'menu-down'"> </b-icon>
+              </a>
+            </div>
+          </template>
+
+          <div class="card-content">
+            <b-collapse
+              class="mb-4"
+              animation="slide"
+              v-for="(v, index) of pastOfficers"
+              :key="index"
+            >
+              <template #trigger="props">
+                <a class="has-text-black">
+                  <b-icon :icon="props.open ? 'menu-up' : 'menu-down'"></b-icon>
+                  {{ v.term }}
+                </a>
+              </template>
+
+              <b-table class="mt-2" :data="v.table">
+                <b-table-column
+                  field="gm"
+                  width="50%"
+                  label="General Managers"
+                  v-slot="props"
+                >
+                  {{
+                    (props.row.gm &&
+                      props.row.gm.name + " @" + props.row.gm.handle) ||
+                      ""
+                  }}
+                </b-table-column>
+                <b-table-column field="sm" label="Site Managers" v-slot="props">
+                  {{
+                    (props.row.sm &&
+                      props.row.sm.name + " @" + props.row.sm.handle) ||
+                      ""
+                  }}
+                </b-table-column>
+              </b-table>
+            </b-collapse>
+          </div>
+        </b-collapse>
       </div>
     </section>
   </Layout>
@@ -111,6 +169,7 @@
 
 <script>
 import OfficerCardSet from "../../components/OfficerCardSet";
+import PastOfficersData from "@/assets/officers-data/past-officers.json";
 
 export default {
   metaInfo: {
@@ -121,7 +180,8 @@ export default {
   },
   data() {
     return {
-      cards: []
+      cards: [],
+      pastOfficers: []
     };
   },
   created() {
@@ -215,6 +275,18 @@ export default {
         icon: "https://bulma.io/images/placeholders/96x96.png"
       }
     ];
+
+    for (var i = 0; i < PastOfficersData.pastOfficers.length; i++) {
+      var data = PastOfficersData.pastOfficers[i];
+      this.pastOfficers[i] = { term: data.term, table: [] };
+      var len = Math.max(data.gms.length, data.sms.length);
+      for (var k = 0; k < len; k++) {
+        this.pastOfficers[i].table[k] = {
+          gm: data.gms[k] || "",
+          sm: data.sms[k] || ""
+        };
+      }
+    }
   }
 };
 </script>


### PR DESCRIPTION
I had previously implemented this feature in #205, but Jenkins decided it would have none of it. Now 4 months after, we've both grown a considerable amount, and have learned to put our differences aside for the good of the OCF and World Peace™.
This is the result:
![image](https://user-images.githubusercontent.com/18639132/136753806-8708e106-400f-4fd2-8486-49ef4a9b62cd.png)
This is addressing issue #198.

I created a json file in the assets folder with all the past officers data. I then parse that file in `Officers.vue` to construct it into a table inside a dropdown.

The good thing of this approach is that it's not hard coded and updating past officers will simply need an edit to the json file.

I look forward to pushing this merge together.