### PR TITLE
Change to node16 rather than current

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:current AS build-env
+FROM node:16 AS build-env
 WORKDIR /build
 COPY . .
 RUN npm install && npm run build


### PR DESCRIPTION
jenkins was failing with all commits due to update to NodeJS 17. We are now fixing at 16 in Dockerfile; 16 is the LTS version anyway.